### PR TITLE
Recognition of absolute URL

### DIFF
--- a/src/LottieAnimation.vue
+++ b/src/LottieAnimation.vue
@@ -63,9 +63,27 @@ export default {
   },
   methods: {
     async loadJsonData(path) {
-      return await axios.get("/" + path).then(response => {
+      let p;
+      if(this.isURL(path)) p = path;
+      else p = "/"+path;
+
+      return await axios.get(p).then(response => {
         return response.data;
       });
+    },
+    isURL(path){
+      // just something I stole from stack
+      // https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
+
+      let urlpattern = new RegExp(
+        '^(https?:\\/\\/)?'+ // protocol
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
+        '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
+        '(\\?[;&a-z\\d%_.~+=-]*)?' // query string
+      ,'i'); // fragment locator
+
+      return !!urlpattern.test(path);
     },
     async init() {
       this.style = {


### PR DESCRIPTION
I had trouble when using absolute URLs as they would prepend a `http://localhost` hostname.
Forked the repo to investigate and noted the `axios.get` defaulted this way.

I added a method which recognises whether an absolute url has been supplied and sets a path variable `p` accordingly to be used with axios.

Cheers